### PR TITLE
fix: set new position on componentDidUpdate

### DIFF
--- a/src/Marker.tsx
+++ b/src/Marker.tsx
@@ -43,8 +43,8 @@ export class Marker extends React.Component<MarkerProps> {
   public componentDidUpdate(prevProps: MarkerProps) {
     if (prevProps.lat !== this.props.lat || prevProps.lng !== this.props.lng) {
       this.setPosition({
-        lat: prevProps.lat,
-        lng: prevProps.lng,
+        lat: this.props.lat,
+        lng: this.props.lng,
       })
     }
   }


### PR DESCRIPTION
The Marker `componentDidUpdate` method was setting the `prevProps` as the new position which caused the marker to stay on the same place.